### PR TITLE
Fix sparkline not work with lower version of jquery

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facets Component developed by Uncharted Software",
   "repository": "https://github.com/unchartedsoftware/stories-facets",
   "license": "Apache-2.0",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "devDependencies": {
     "body-parser": "~1.13.2",
     "browserify": "^12.0.1",

--- a/src/components/facet/facetVertical.js
+++ b/src/components/facet/facetVertical.js
@@ -452,8 +452,8 @@ FacetVertical.prototype._updateSparkline = function() {
 			var selectedSparklinePath = this._renderSparkline(sparkWidth,sparkHeight,this._spec.selected.timeseries, maxValue);
 			selectedSparklinePath.appendTo(sparkline);
 
-			totalSparklinePath.addClass('facet-sparkline-total');
-			selectedSparklinePath.addClass('facet-sparkline-selected');
+			totalSparklinePath[0].classList.add('facet-sparkline-total');
+			selectedSparklinePath[0].classList.add('facet-sparkline-selected');
 
 			if (this._spec.isQuery && this._spec.icon && this._spec.icon.color) {
 				selectedSparklinePath.css('stroke', this._spec.icon.color);


### PR DESCRIPTION
Fixed the issue that sparkline is not styled properly with lower version of jquery (especially the one used in the Power Bi desktop version) because $.addClass method doesn't work with svg tags. 