### PR TITLE
Bugfix/histogram bucket bars have incorrect height

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facets Component developed by Uncharted Software",
   "repository": "https://github.com/unchartedsoftware/stories-facets",
   "license": "Apache-2.0",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "devDependencies": {
     "body-parser": "~1.13.2",
     "browserify": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facets Component developed by Uncharted Software",
   "repository": "https://github.com/unchartedsoftware/stories-facets",
   "license": "Apache-2.0",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "devDependencies": {
     "body-parser": "~1.13.2",
     "browserify": "^12.0.1",

--- a/src/components/facet/facetHistogram.js
+++ b/src/components/facet/facetHistogram.js
@@ -34,7 +34,7 @@ function FacetHistogram (svgContainer, spec) {
 	this._barPadding = ('barPadding' in spec) ? spec.barPadding : 1;
 	this._bars = [];
 
-	this.initializeSlices(svgContainer, spec.slices, spec.yMax);
+	this.initializeSlices(svgContainer, spec.slices);
 }
 
 /**
@@ -95,9 +95,8 @@ Object.defineProperty(FacetHistogram.prototype, 'bars', {
  * @method initializeSlices
  * @param {element} svg - The SVG element where the slices should be created.
  * @param {Array} slices - An array containing the slices to be created.
- * @param {Number} yMax - The maximum value, in the Y axis, that any given slice will have.
  */
-FacetHistogram.prototype.initializeSlices = function(svg, slices, yMax) {
+FacetHistogram.prototype.initializeSlices = function(svg, slices) {
 	var svgWidth = svg.width();
 	var svgHeight = svg.height();
 
@@ -116,21 +115,33 @@ FacetHistogram.prototype.initializeSlices = function(svg, slices, yMax) {
 	barWidth = Math.min(barWidth, maxBarWidth);
 	this._barWidth = barWidth;
 
+	var yMax = 0;
 	for (var i = 0; i < barsLength; i += stackedBarsNumber) {
 		var metadata = [];
 		var count = 0;
 		for (var ii = 0; ii < stackedBarsNumber && (i + ii) < barsLength; ++ii) {
 			var slice = slices[i + ii];
 			slice.toLabel = slice.toLabel || slice.label;
-			count = Math.max(count, slice.count);
+			count += slice.count;
 			metadata.push(slice);
 		}
-		var barHeight = Math.ceil(svgHeight * (count / yMax));
-		var bar = new FacetBar(svg, x, barWidth, barHeight, svgHeight);
+	  yMax = Math.max(yMax, count);
+		var bar = new FacetBar(svg, x, barWidth, 0, svgHeight);
 		bar.highlighted = false;
 		bar.metadata = metadata;
 		this._bars.push(bar);
 		x += barWidth + barPadding;
+	}
+
+	//Set the bar heights using the computed max y value
+	for (var j = 0; j < this._bars.length; j++) {
+		var metaDataArr = this._bars[j].metadata;
+		var total = 0;
+		for (var jj = 0; jj < metaDataArr.length; jj++){
+			total += metaDataArr[jj].count;
+		}
+
+		this._bars[j].height = Math.ceil(svgHeight * (total/yMax));
 	}
 
 	this._totalWidth = x - barPadding;

--- a/src/components/facet/facetHistogram.js
+++ b/src/components/facet/facetHistogram.js
@@ -33,6 +33,7 @@ function FacetHistogram (svgContainer, spec) {
 	this._maxBarWidth = ('maxBarWidth' in spec) ? spec.maxBarWidth : Number.MAX_VALUE;
 	this._barPadding = ('barPadding' in spec) ? spec.barPadding : 1;
 	this._bars = [];
+	this._maxBarHeight = 0;
 
 	this.initializeSlices(svgContainer, spec.slices);
 }
@@ -145,6 +146,7 @@ FacetHistogram.prototype.initializeSlices = function(svg, slices) {
 	}
 
 	this._totalWidth = x - barPadding;
+	this._maxBarHeight = yMax;
 };
 
 /**
@@ -196,7 +198,7 @@ FacetHistogram.prototype.highlightRange = function (range) {
  */
 FacetHistogram.prototype.select = function (slices) {
 	var bars = this._bars;
-	var yMax = this._spec.yMax;
+	var yMax = this._maxBarHeight;
 	var svgHeight = this._svg.height();
 
 	for (var i = 0, n = bars.length; i < n; ++i) {

--- a/src/components/facet/facetHorizontal.js
+++ b/src/components/facet/facetHorizontal.js
@@ -254,7 +254,6 @@ FacetHorizontal.prototype.processHistogram = function(inData) {
 
 	var inSlices = inData.slices;
 	var outSlices = outData.slices;
-	var yMax = 0;
 
 	var index = 0;
 	for (var i = 0, n = inSlices.length; i < n; ++i, ++index) {
@@ -268,10 +267,7 @@ FacetHorizontal.prototype.processHistogram = function(inData) {
 		}
 
 		outSlices.push(slice);
-		yMax = Math.max(yMax, slice.count);
 	}
-
-	outData.yMax = yMax;
 
 	return outData;
 };


### PR DESCRIPTION
Height of the histogram bars was being calculated using the max value of the histogram bucket, instead of the sum of values.