### PR TITLE
Option to disable transitions on init or replace

### DIFF
--- a/examples/replace/replace.js
+++ b/examples/replace/replace.js
@@ -56,7 +56,7 @@ function main() {
 		            ]
 		        }
 			];
-            f.replace(newGroups, newQueries);
+            f.replace(newGroups, newQueries, true); //disables CSS animations during replace
         })
         .appendTo($controls);
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facets Component developed by Uncharted Software",
   "repository": "https://github.com/unchartedsoftware/stories-facets",
   "license": "Apache-2.0",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "devDependencies": {
     "body-parser": "~1.13.2",
     "browserify": "^12.0.1",

--- a/sass/_facet.scss
+++ b/sass/_facet.scss
@@ -513,3 +513,7 @@
 	height: 0;
 	opacity: 0;
 }
+
+.facets-no-transition *{
+	transition: none !important;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -128,10 +128,11 @@ Facets.prototype.deselect = function(simpleGroups) {
  * @method replace
  * @param {Object} groups - An object describing the groups of facets to be created.
  * @param {Object=} queries - Optional object describing the queries that should be created along with the facets.
+ * @param {boolean=} noTransition - If truthful will disable CSS transitions during init.
  */
-Facets.prototype.replace = function(groups, queries) {
+Facets.prototype.replace = function(groups, queries, noTransition) {
 	this._destroyContents();
-	this._init(groups, queries);
+	this._init(groups, queries, noTransition);
 };
 
 /**
@@ -380,9 +381,14 @@ Facets.prototype.destroy = function() {
  * @method _init
  * @param {Object} groups - An object describing the groups to instantiate with this widget.
  * @param {Object=} queries - An optional object describing the queries to instantiate with this widget.
+ * @param {boolean=} noTransition - If truthful will disable CSS transitions during init.
  * @private
  */
-Facets.prototype._init = function(groups, queries) {
+Facets.prototype._init = function(groups, queries, noTransition) {
+
+	if ( noTransition ) {
+		this._container.addClass('facets-no-transition');
+	}
 	this._queryGroup = new QueryGroup(this._container, queries || []);
 
 	// Create groups
@@ -391,6 +397,10 @@ Facets.prototype._init = function(groups, queries) {
 	}.bind(this));
 
 	this._bindClientEvents();
+
+    if ( noTransition ) {
+        this._container.removeClass('facets-no-transition');
+    }
 };
 
 /**


### PR DESCRIPTION
Since it's easier to override this on parent element I went with the !important mechanic.  Alternative solution would be to disable specific animation but that's a set that may grow in the future so not a great solution. 