### PR TITLE
Add 'removeGroup' and 'getGroup' methods to Facet object.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facets Component developed by Uncharted Software",
   "repository": "https://github.com/unchartedsoftware/stories-facets",
   "license": "Apache-2.0",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "devDependencies": {
     "body-parser": "~1.13.2",
     "browserify": "^12.0.1",

--- a/src/main.js
+++ b/src/main.js
@@ -363,6 +363,20 @@ Facets.prototype.removeFacet = function(key, value) {
 };
 
 /**
+ * Removes the group with the specified key.
+ *
+ * @method removeGroup
+ * @param {*} key - The key of the group containing the facet to remove.
+ */
+Facets.prototype.removeGroup = function(key) {
+	var group = this._getGroup(key);
+	if (group) {
+		group.destroy();
+		this._groups.splice(this._groups.indexOf(group), 1);
+	}
+};
+
+/**
  * Adds a query to the query group in this widget.
  *
  * @method addQuery

--- a/src/main.js
+++ b/src/main.js
@@ -515,6 +515,8 @@ Facets.prototype.getGroup = function(key) {
 		return null;
 	}
 };
+// alias for backwards compatibility
+Facets.prototype._getGroup = Facets.prototype.getGroup;
 
 /**
  * Internal method to destroy the groups, facets and queries contained in this widget.

--- a/src/main.js
+++ b/src/main.js
@@ -59,7 +59,7 @@ Facets.prototype.select = function(subgroups, isQuery) {
 	var queriesInitialized = false;
 
 	subgroups.forEach(function(groupSpec) {
-		var group = this._getGroup(groupSpec.key);
+		var group = this.getGroup(groupSpec.key);
 		if (!isQuery && group) {
 			if (!groupsInitialized) {
 				// Initialize selection state
@@ -107,7 +107,7 @@ Facets.prototype.deselect = function(simpleGroups) {
 		});
 	} else {
 		simpleGroups.forEach(function(simpleGroup) {
-			var group = this._getGroup(simpleGroup.key);
+			var group = this.getGroup(simpleGroup.key);
 			if (group) {
 				if ('value' in simpleGroup) {
 					var facet = group._getFacet(simpleGroup.value);
@@ -143,7 +143,7 @@ Facets.prototype.replace = function(groups, queries, noTransition) {
  * @param {Object} group - An object describing the information of the new group.
  */
 Facets.prototype.replaceGroup = function(group) {
-	var existingGroup = this._getGroup(group.key);
+	var existingGroup = this.getGroup(group.key);
 	if (existingGroup) {
 		existingGroup.replace(group);
 		this._bindClientEvents();
@@ -159,7 +159,7 @@ Facets.prototype.replaceGroup = function(group) {
  */
 Facets.prototype.highlight = function(simpleGroups, isQuery) {
 	simpleGroups.forEach(function(simpleGroup) {
-		var group = this._getGroup(simpleGroup.key);
+		var group = this.getGroup(simpleGroup.key);
 		if (!isQuery && group) {
 			group.highlight(simpleGroup.value);
 		} else {
@@ -181,7 +181,7 @@ Facets.prototype.highlight = function(simpleGroups, isQuery) {
 Facets.prototype.createBadges = function(simpleGroups, isQuery) {
 
   simpleGroups.forEach(function(simpleGroup) {
-		var group = this._getGroup(simpleGroup.key);
+		var group = this.getGroup(simpleGroup.key);
 		if (!isQuery && group) {
 			this._badgeGroup._createBadge(simpleGroup);
 		} else {
@@ -208,7 +208,7 @@ Facets.prototype.removeBadges = function(simpleGroups, isQuery) {
     this._badgeGroup._removeAllBadges();
 	} else {
     simpleGroups.forEach(function(simpleGroup) {
-  		var group = this._getGroup(simpleGroup.key);
+  		var group = this.getGroup(simpleGroup.key);
   		if (!isQuery && group) {
         this._badgeGroup._removeBadge(simpleGroup.key, simpleGroup.value);
   		} else {
@@ -231,7 +231,7 @@ Facets.prototype.removeBadges = function(simpleGroups, isQuery) {
 Facets.prototype.unhighlight = function(simpleGroups, isQuery) {
 	if (arguments.length > 0) {
 		simpleGroups.forEach(function(simpleGroup) {
-			var group = this._getGroup(simpleGroup.key);
+			var group = this.getGroup(simpleGroup.key);
 			if (!isQuery && group) {
 				group.unhighlight(simpleGroup.value);
 			} else {
@@ -255,7 +255,7 @@ Facets.prototype.unhighlight = function(simpleGroups, isQuery) {
  * @returns {boolean}
  */
 Facets.prototype.isHighlighted = function(simpleGroup, isQuery) {
-	var group = this._getGroup(simpleGroup.key);
+	var group = this.getGroup(simpleGroup.key);
 	if (!isQuery && group) {
 		return group.isHighlighted(simpleGroup.value);
 	} else {
@@ -275,7 +275,7 @@ Facets.prototype.isHighlighted = function(simpleGroup, isQuery) {
  * @returns {boolean}
  */
 Facets.prototype.isCollapsed = function(key) {
-	var group = this._getGroup(key);
+	var group = this.getGroup(key);
 	if (group) {
 		return group.collapsed;
 	}
@@ -291,7 +291,7 @@ Facets.prototype.isCollapsed = function(key) {
  * @returns {Object|null}
  */
 Facets.prototype.getFilterRange = function(key, value) {
-	var group = this._getGroup(key);
+	var group = this.getGroup(key);
 	if (group) {
 		return group.getFilterRange(value);
 	}
@@ -305,7 +305,7 @@ Facets.prototype.getFilterRange = function(key, value) {
  * @param spec the spec values to replace
  */
 Facets.prototype.updateSpec = function(groupKey,facetKey,spec) {
-	var group = this._getGroup(groupKey);
+	var group = this.getGroup(groupKey);
 	if (group) {
 		var facet = group._getFacet(facetKey);
 		if (facet) {
@@ -328,7 +328,7 @@ Facets.prototype.append = function(groups, queries) {
 	// Append groups
 	if (groups) {
 		groups.forEach(function(groupSpec) {
-			existingGroup = this._getGroup(groupSpec.key);
+			existingGroup = this.getGroup(groupSpec.key);
 			if (existingGroup) {
 				existingGroup.append(groupSpec);
 			} else {
@@ -356,7 +356,7 @@ Facets.prototype.append = function(groups, queries) {
  * @param {*} value - The value of the facet to remove.
  */
 Facets.prototype.removeFacet = function(key, value) {
-	var group = this._getGroup(key);
+	var group = this.getGroup(key);
 	if (group) {
 		group.removeFacet(value);
 	}
@@ -369,7 +369,7 @@ Facets.prototype.removeFacet = function(key, value) {
  * @param {*} key - The key of the group containing the facet to remove.
  */
 Facets.prototype.removeGroup = function(key) {
-	var group = this._getGroup(key);
+	var group = this.getGroup(key);
 	if (group) {
 		group.destroy();
 		this._groups.splice(this._groups.indexOf(group), 1);
@@ -500,12 +500,12 @@ Facets.prototype._getQuery = function(key, value) {
 /**
  * Gets the group with the specified key.
  *
- * @method _getGroup
+ * @method getGroup
  * @param {string} key - The key of the group to find.
  * @returns {Group|null}
  * @private
  */
-Facets.prototype._getGroup = function(key) {
+Facets.prototype.getGroup = function(key) {
 	var groupObj = this._groups.filter(function(g) {
 		return g.key === key;
 	});

--- a/tests/facetAppendTests.js
+++ b/tests/facetAppendTests.js
@@ -59,13 +59,13 @@ describe('Append', function() {
 		testSupport.verifyQuery(secondQueryQuery, secondQueryQuery._element, '*', 'second query', 8, 10, '80%');
 
 		// Verify baseline groups/facets
-		var phoneGroup = facetsComponent._getGroup('phones');
+		var phoneGroup = facetsComponent.getGroup('phones');
 		var firstPhoneFacet = phoneGroup._getFacet('111 111 1111');
 		var secondPhoneFacet = phoneGroup._getFacet('222 222 2222');
 		testSupport.verifyFacet(firstPhoneFacet, firstPhoneFacet._element, 'phones', '111 111 1111', 10, 40, 'orange', '25%');
 		testSupport.verifyFacet(secondPhoneFacet, secondPhoneFacet._element, 'phones', '222 222 2222', 30, 40, 'blue', '75%');
 
-		var nameGroup = facetsComponent._getGroup('names');
+		var nameGroup = facetsComponent.getGroup('names');
 		var firstNameFacet = nameGroup._getFacet('Maya');
 		testSupport.verifyFacet(firstNameFacet, firstNameFacet._element, 'names', 'Maya', 20, 20, 'grey', '100%');
 	});
@@ -84,7 +84,7 @@ describe('Append', function() {
 		facetsComponent.append(groupsToAppend);
 
 		// Then expect names group to be updated
-		var nameGroup = facetsComponent._getGroup('names');
+		var nameGroup = facetsComponent.getGroup('names');
 		var firstNameFacet = nameGroup._getFacet('Maya');
 		var secondNameFacet = nameGroup._getFacet('John');
 		testSupport.verifyFacet(firstNameFacet, firstNameFacet._element, 'names', 'Maya', 20, 80, 'grey', '25%');
@@ -101,7 +101,7 @@ describe('Append', function() {
 		facetsComponent.append(groupsToAppend);
 
 		// Then expect new group added
-		var fooGroup = facetsComponent._getGroup('foo');
+		var fooGroup = facetsComponent.getGroup('foo');
 		var fooFacet = fooGroup._getFacet('bar');
 		testSupport.verifyFacet(fooFacet, fooFacet._element, 'foo', 'bar', 60, 60, 'grey', '100%');
 	});
@@ -116,7 +116,7 @@ describe('Append', function() {
 		facetsComponent.append(groupsToAppend);
 
 		// Then expect phone group modified
-		var phoneGroup = facetsComponent._getGroup('phones');
+		var phoneGroup = facetsComponent.getGroup('phones');
 		var firstPhoneFacet = phoneGroup._getFacet('111 111 1111');
 		var secondPhoneFacet = phoneGroup._getFacet('222 222 2222');
 		testSupport.verifyFacet(firstPhoneFacet, firstPhoneFacet._element, 'phones', '111 111 1111', 10, 50, 'orange', '20%');

--- a/tests/facetClickTests.js
+++ b/tests/facetClickTests.js
@@ -58,7 +58,7 @@ describe('Click', function() {
 		facetsComponent.on('facet:click', onFacetClick);
 
 		// When a facet is clicked
-		var phoneGroup = facetsComponent._getGroup('phone');
+		var phoneGroup = facetsComponent.getGroup('phone');
 		var secondPhoneFacet = phoneGroup._getFacet('222 222 2222');
 		$(secondPhoneFacet._element).trigger('click');
 
@@ -79,7 +79,7 @@ describe('Click', function() {
 		]);
 
 		// ... and the modified name is clicked
-		var nameGroup = facetsComponent._getGroup('name');
+		var nameGroup = facetsComponent.getGroup('name');
 		var secondNameFacet = nameGroup._getFacet('John');
 		$(secondNameFacet._element).trigger('click');
 
@@ -100,7 +100,7 @@ describe('Click', function() {
 		]);
 
 		// ... and the newly added name is clicked
-		var nameGroup = facetsComponent._getGroup('name');
+		var nameGroup = facetsComponent.getGroup('name');
 		var secondNameFacet = nameGroup._getFacet('Maya');
 		$(secondNameFacet._element).trigger('click');
 
@@ -120,7 +120,7 @@ describe('Click', function() {
 		facetsComponent.off('facet:click');
 
 		// ...and a facet is clicked
-		var phoneGroup = facetsComponent._getGroup('phone');
+		var phoneGroup = facetsComponent.getGroup('phone');
 		var secondPhoneFacet = phoneGroup._getFacet('222 222 2222');
 		$(secondPhoneFacet._element).trigger('click');
 

--- a/tests/facetCollapseExpandTests.js
+++ b/tests/facetCollapseExpandTests.js
@@ -52,8 +52,8 @@ describe('Expand and Collapse', function() {
 	});
 
 	it('Groups are expanded by default', function() {
-		var phoneGroup = facetsComponent._getGroup('phone');
-		var nameGroup = facetsComponent._getGroup('name');
+		var phoneGroup = facetsComponent.getGroup('phone');
+		var nameGroup = facetsComponent.getGroup('name');
 
 		expect(phoneGroup.collapsed).to.be.false;
 		expect(phoneGroup._element.hasClass('facets-group-collapsed')).to.be.false;
@@ -63,7 +63,7 @@ describe('Expand and Collapse', function() {
 
 	it('Toggles group collapse on click', function() {
 		// Given
-		var phoneGroup = facetsComponent._getGroup('phone');
+		var phoneGroup = facetsComponent.getGroup('phone');
 		var phoneGroupExpander = phoneGroup._element.find('.group-expander');
 
 		// When
@@ -83,7 +83,7 @@ describe('Expand and Collapse', function() {
 
 	it('Emits collapse and expand events with group key', function() {
 		// Given
-		var phoneGroup = facetsComponent._getGroup('phone'),
+		var phoneGroup = facetsComponent.getGroup('phone'),
 			phoneGroupIcon = phoneGroup._element.find('.group-expander'),
 			onGroupCollapse = sinon.spy(),
 			onGroupExpand = sinon.spy();
@@ -117,7 +117,7 @@ describe('Expand and Collapse', function() {
 		]);
 
 		// ... and new group is collapsed and expanded
-		var fooGroup = facetsComponent._getGroup('foo'),
+		var fooGroup = facetsComponent.getGroup('foo'),
 			fooGroupIcon = fooGroup._element.find('.group-expander');
 		fooGroupIcon.trigger('click');
 		fooGroupIcon.trigger('click');

--- a/tests/facetDestroyTests.js
+++ b/tests/facetDestroyTests.js
@@ -91,8 +91,8 @@ describe('Destroy', function() {
 		facetsComponent.on('facet-group:more', onGroupMore);
 
 		// Then event handlers are persisted in component
-		var phoneGroup = facetsComponent._getGroup('phones');
-		var nameGroup = facetsComponent._getGroup('names');
+		var phoneGroup = facetsComponent.getGroup('phones');
+		var nameGroup = facetsComponent.getGroup('names');
 		var phoneFacet = phoneGroup._getFacet('111 111 1111');
 		var nameFacet = nameGroup._getFacet('Maya');
 

--- a/tests/facetDisplayTests.js
+++ b/tests/facetDisplayTests.js
@@ -57,7 +57,7 @@ describe('Display', function() {
 		var secondQueryElement = secondQuery._element;
 		testSupport.verifyQuery(secondQuery, secondQueryElement, '*', 'Toronto', 6, 10, '60%');
 
-		var phoneGroup = facetsComponent._getGroup('phones');
+		var phoneGroup = facetsComponent.getGroup('phones');
 		var firstFacet = phoneGroup._getFacet('111 111 1111');
 		var secondFacet = phoneGroup._getFacet('222 222 2222');
 		testSupport.verifyFacet(firstFacet, firstFacet._element, 'phones', '111 111 1111', 10, 40, 'orange', '25%'); // total is sum of facets in group
@@ -80,7 +80,7 @@ describe('Display', function() {
 		expect(facetsComponent._queryGroup.visible).to.equal(false);
 
 		// And facet groups rendered same as always
-		var phoneGroup = facetsComponent._getGroup('phones');
+		var phoneGroup = facetsComponent.getGroup('phones');
 		var firstFacet = phoneGroup._getFacet('111 111 1111');
 		var secondFacet = phoneGroup._getFacet('222 222 2222');
 		testSupport.verifyFacet(firstFacet, firstFacet._element, 'phones', '111 111 1111', 10, 40, 'orange', '25%'); // total is sum of facets in group
@@ -100,7 +100,7 @@ describe('Display', function() {
 		var facetsComponent = new Facets(container[0], groups);
 
 		// Then
-		var personaGroup = facetsComponent._getGroup('persona');
+		var personaGroup = facetsComponent.getGroup('persona');
 		var personaFacet = personaGroup._getFacet('333 333 3333');
 		var personaLink = personaFacet._element.find('.facet-links');
 		expect(personaLink.text().trim()).to.equal('333');

--- a/tests/facetMoreTests.js
+++ b/tests/facetMoreTests.js
@@ -54,19 +54,19 @@ describe('More', function() {
 
 	it('Displays a more link if provided', function() {
 		// Phone group has more link
-		var phoneGroup = facetsComponent._getGroup('phone');
+		var phoneGroup = facetsComponent.getGroup('phone');
 		var phoneMoreCount = phoneGroup._element.find('.group-other-label-count');
 		expect(phoneMoreCount.text()).to.equal('15+');
 
 		// Name group does not have more link
-		var nameGroup = facetsComponent._getGroup('name');
+		var nameGroup = facetsComponent.getGroup('name');
 		var nameMoreCount = nameGroup._element.find('.group-other-label-count');
 		expect(nameMoreCount.text()).to.equal('');
 	});
 
 	it('Emits more event with group key', function() {
 		// Given
-		var phoneGroup = facetsComponent._getGroup('phone'),
+		var phoneGroup = facetsComponent.getGroup('phone'),
 			phoneMore = phoneGroup._element.find('.group-more-target'),
 			onGroupMore = sinon.spy();
 
@@ -91,7 +91,7 @@ describe('More', function() {
 		]);
 
 		// ...and the newly added more link is clicked
-		var nameGroup = facetsComponent._getGroup('name'),
+		var nameGroup = facetsComponent.getGroup('name'),
 			nameMore = nameGroup._element.find('.group-more-target');
 		nameMore.trigger('click');
 

--- a/tests/facetMouseTests.js
+++ b/tests/facetMouseTests.js
@@ -60,7 +60,7 @@ describe('Mouse Events', function() {
 		facetsComponent.on('facet:mouseleave', onMouseLeave);
 
 		// When first phone icon is hovered over
-		var phoneGroup = facetsComponent._getGroup('phone'),
+		var phoneGroup = facetsComponent.getGroup('phone'),
 			firstPhoneFacet = phoneGroup._getFacet('111 111 1111'),
 			firstPhoneIcon = firstPhoneFacet._element.find('.facet-icon');
 		firstPhoneIcon.trigger('mouseenter');
@@ -89,7 +89,7 @@ describe('Mouse Events', function() {
 		]);
 
 		// ...and the newly added name icon is hovered over
-		var nameGroup = facetsComponent._getGroup('name'),
+		var nameGroup = facetsComponent.getGroup('name'),
 			johnFacet = nameGroup._getFacet('John'),
 			johnIcon = johnFacet._element.find('.facet-icon');
 		johnIcon.trigger('mouseenter');
@@ -117,7 +117,7 @@ describe('Mouse Events', function() {
 		facetsComponent.off('facet:mouseleave');
 
 		// ... and a hover is triggerred
-		var phoneGroup = facetsComponent._getGroup('phone'),
+		var phoneGroup = facetsComponent.getGroup('phone'),
 			firstPhoneFacet = phoneGroup._getFacet('111 111 1111'),
 			firstPhoneIcon = firstPhoneFacet._element.find('.facet-icon');
 		firstPhoneIcon.trigger('mouseenter');

--- a/tests/facetReplaceTests.js
+++ b/tests/facetReplaceTests.js
@@ -71,15 +71,15 @@ describe('Replace', function() {
 		// Then expect old elements are removed...
 		expect(facetsComponent._getQuery('*', 'test phrase')).to.be.null;
 		expect(facetsComponent._getQuery('*', 'query text')).to.be.null;
-		expect(facetsComponent._getGroup('phones')).to.be.null;
-		expect(facetsComponent._getGroup('names')).to.be.null;
+		expect(facetsComponent.getGroup('phones')).to.be.null;
+		expect(facetsComponent.getGroup('names')).to.be.null;
 
 		// ... and new elements are added
 		var torontoQuery = facetsComponent._getQuery('place', 'toronto');
 		var torontoQueryElement = torontoQuery._element;
 		testSupport.verifyQuery(torontoQuery, torontoQueryElement, 'place', 'toronto', 6, 6, '100%');
 
-		var websiteGroup = facetsComponent._getGroup('websites');
+		var websiteGroup = facetsComponent.getGroup('websites');
 		var firstFacet = websiteGroup._getFacet('www.test1.example.com');
 		var secondFacet = websiteGroup._getFacet('www.test2.example.com');
 		testSupport.verifyFacet(firstFacet, firstFacet._element, 'websites', 'www.test1.example.com', 30, 60, 'grey', '50%');
@@ -122,7 +122,7 @@ describe('Replace', function() {
 		facetsComponent.replace(newGroupSpecs, newQuerySpecs);
 
 		// ...and events are triggerred
-		var websiteGroup = facetsComponent._getGroup('websites'),
+		var websiteGroup = facetsComponent.getGroup('websites'),
 			websiteMore = websiteGroup._element.find('.group-more-target'),
 			websiteGroupExpandIcon = websiteGroup._element.find('.group-expander'),
 			websiteFacet = websiteGroup._getFacet('www.test1.example.com'),

--- a/tests/facetSearchTests.js
+++ b/tests/facetSearchTests.js
@@ -134,7 +134,7 @@ describe('Search', function() {
 		expect(onFacetClick.called).to.be.false;
 
 		// However, when the general area of the facet is clicked...
-		var nameGroup = facetsComponent._getGroup('name');
+		var nameGroup = facetsComponent.getGroup('name');
 		var secondNameFacet = nameGroup._getFacet('Maya');
 		$(secondNameFacet._element).trigger('click');
 

--- a/tests/facetSelectionTests.js
+++ b/tests/facetSelectionTests.js
@@ -76,7 +76,7 @@ describe('Selection', function() {
 		facetsComponent.select(subgroups);
 
 		// Then name facets rendered as selected with additional bar
-		var nameGroup = facetsComponent._getGroup('name');
+		var nameGroup = facetsComponent.getGroup('name');
 		var mayaFacet = nameGroup._getFacet('Maya');
 		var debbieFacet = nameGroup._getFacet('Debbie');
 		testSupport.verifySelectedFacet(mayaFacet, mayaFacet._element, 'name', 'Maya', 30, 40, '75%', '10%');
@@ -101,7 +101,7 @@ describe('Selection', function() {
 		facetsComponent.deselect(subgroups);
 
 		// Then facets are unselected
-		var nameGroup = facetsComponent._getGroup('name');
+		var nameGroup = facetsComponent.getGroup('name');
 		var mayaFacet = nameGroup._getFacet('Maya');
 		var debbieFacet = nameGroup._getFacet('Debbie');
 		testSupport.verifyDeselectedFacet(mayaFacet, mayaFacet._element, 'name', 'Maya', 30, 40, 'grey', '75%');

--- a/tests/test-support.js
+++ b/tests/test-support.js
@@ -61,7 +61,7 @@ module.exports = {
 	},
 
 	_findFacetElement: function(facetsComponent, groupKey, facetValue) {
-		var group = facetsComponent._getGroup(groupKey);
+		var group = facetsComponent.getGroup(groupKey);
 		return group._getFacet(facetValue);
 	},
 
@@ -86,7 +86,7 @@ module.exports = {
 	},
 
 	findSearchIcon: function(facetsComponent, groupStr, facetString) {
-		var group = facetsComponent._getGroup(groupStr);
+		var group = facetsComponent.getGroup(groupStr);
 		var facet = group._getFacet(facetString);
 		return facet._element.find('.facet-search');
 	},


### PR DESCRIPTION
Adds a `removeGroup` method to the `Facets` object.

Expose `_getGroup` as `getGroup` while maintaining an alias to `_getGroup` to prevent any breaking changes.

Resolves #11 