### PR TITLE
Floating point string label comparison in selection

### DIFF
--- a/src/components/facet/facetHorizontal.js
+++ b/src/components/facet/facetHorizontal.js
@@ -184,12 +184,12 @@ FacetHorizontal.prototype.select = function(data) {
 				for (var ii = 0, nn = barMetadata.length; ii < nn; ++ii) {
 					var slice = barMetadata[ii];
 
-					if (fromIsString && slice.label === from) {
+					if (fromIsString && (slice.label === from || +slice.label === +from)) {
 						from = i;
 						fromIsString = false;
 					}
 
-					if (toIsString && slice.toLabel === to) {
+					if (toIsString && (slice.toLabel === to || +slice.toLabel === +to)) {
 						to = i;
 						toIsString = false;
 					}


### PR DESCRIPTION
Fix issues when using string label comparisons for floating point values in horizontal facet selections. 

Ex. comparing a `from` string of '0.1640' to '0.164' would previously fail, resulting in no selection.