### PR TITLE
Remove pre-emptively forced layouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facets Component developed by Uncharted Software",
   "repository": "https://github.com/unchartedsoftware/stories-facets",
   "license": "Apache-2.0",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "devDependencies": {
     "body-parser": "~1.13.2",
     "browserify": "^12.0.1",

--- a/src/components/facet/facetHistogramBar.js
+++ b/src/components/facet/facetHistogramBar.js
@@ -128,12 +128,10 @@ Object.defineProperty(FacetHistogramBar.prototype, 'height', {
 		if (this._selectedHeight === null) {
 			this._element.attr('height', value);
 			this._element.css('height', value);
-			this._element.css('height');
 		}
 
 		this._backElement.attr('height', value);
 		this._backElement.css('height', value);
-		this._backElement.css('height');
 
 		this._height = value;
 	}
@@ -154,11 +152,9 @@ Object.defineProperty(FacetHistogramBar.prototype, 'selectedHeight', {
 		if (value !== null) {
 			this._element.attr('height', value);
 			this._element.css('height', value);
-			this._element.css('height');
 		} else {
 			this._element.attr('height', this._height);
 			this._element.css('height', this._height);
-			this._element.css('height');
 		}
 
 		this._selectedHeight = value;

--- a/src/components/facet/facetHorizontal.js
+++ b/src/components/facet/facetHorizontal.js
@@ -336,17 +336,6 @@ FacetHorizontal.prototype._initializeLayout = function(template) {
 	this._histogramFilter.setFilterPixelRange({ from: 0, to: this._histogram.totalWidth });
 
 	this._rangeControls = this._element.find('.facet-range-controls');
-
-	/* make sure all styles have been applied */
-	var i, n, off;
-	for (i = 0, n = this._element.length; i < n; ++i) {
-		off = this._element[i].offsetHeight; // trigger style recalculation.
-	}
-
-	var children = this._element.find('*');
-	for (i = 0, n = children.length; i < n; ++i) {
-		off = children[i].offsetHeight; // trigger style recalculation.
-	}
 };
 
 /**

--- a/src/components/facet/facetVertical.js
+++ b/src/components/facet/facetVertical.js
@@ -350,17 +350,6 @@ FacetVertical.prototype._initializeLayout = function(template) {
 	}
 
 	this._sparklineContainer = this._element.find('.facet-sparkline-container');
-
-	/* make sure all styles have been applied */
-	var i, n, off;
-	for (i = 0, n = this._element.length; i < n; ++i) {
-		off = this._element[i].offsetHeight; // trigger style recalculation.
-	}
-
-	var children = this._element.find('*');
-	for (i = 0, n = children.length; i < n; ++i) {
-		off = children[i].offsetHeight; // trigger style recalculation.
-	}
 };
 
 /**

--- a/src/components/group.js
+++ b/src/components/group.js
@@ -656,9 +656,7 @@ Group.prototype._updateMore = function (more) {
 		more: more
 	}));
 	this._moreContainer = this._element.find('.group-more-container');
-	this._moreContainer.replaceWith(this._moreElement);
-	/* make sure the DOM is updated at this time */
-	this._moreElement.css('height');
+    this._moreContainer.replaceWith(this._moreElement);
 };
 
 /**


### PR DESCRIPTION
Remove lines of code that pre-emptively read DOM properties which [force layout / reflow](https://gist.github.com/paulirish/5d52fb081b3570c81e3a).

This greatly increases the rendering speeds of histogram facets, since previously it forced a layout for each individual bar.

Removing the code did not cause any issues in our app, I don't _think_ it will cause any issues. My logic being that if any code requires layout specific calculations, it is reading attributes that force layout anyway, so there is no reason to pre-emptively force it when it isn't explicitly required.