### PR TITLE
Add flags to disable collapsing and filtering controls.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facets Component developed by Uncharted Software",
   "repository": "https://github.com/unchartedsoftware/stories-facets",
   "license": "Apache-2.0",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "devDependencies": {
     "body-parser": "~1.13.2",
     "browserify": "^12.0.1",

--- a/src/components/facet/facetHorizontal.js
+++ b/src/components/facet/facetHorizontal.js
@@ -235,7 +235,8 @@ FacetHorizontal.prototype.processSpec = function(inData) {
 	var outData = {
 		histogram: histogram,
 		leftRangeLabel: firstSlice.label,
-		rightRangeLabel: lastSlice.toLabel || lastSlice.label
+		rightRangeLabel: lastSlice.toLabel || lastSlice.label,
+		filterable: inData.filterable !== undefined ? inData.filterable : true
 	};
 	return outData;
 };

--- a/src/components/group.js
+++ b/src/components/group.js
@@ -49,6 +49,7 @@ function Group(widget, container, groupSpec, options, index) {
 
 	this._canDrag = false;
 	this._dragging = false;
+	this._collapsible = groupSpec.collapsible !== undefined ? groupSpec.collapsible : true;
 	this._draggingX = 0;
 	this._draggingY = 0;
 	this._draggingYOffset = 0;
@@ -474,7 +475,8 @@ Group.prototype._destroyFacets = function () {
 Group.prototype._initializeLayout = function (template, label, more, index) {
 	this._element = $(template({
 		label: label,
-		more: more
+		more: more,
+		collapsible: this._collapsible
 	}));
 	if (index === undefined) {
 		// if no index is specified, append to container

--- a/src/components/group.js
+++ b/src/components/group.js
@@ -373,6 +373,9 @@ Group.prototype.replace = function(groupSpec) {
 	this._element.remove();
 	this._setupHandlers();
 
+	// update collapsible state
+	this._collapsible = groupSpec.collapsible !== undefined ? groupSpec.collapsible : true;
+
 	//reinit
 	this._initializeLayout(Template, groupSpec.label, groupSpec.more || 0, index);
 

--- a/templates/facetHorizontal.hbs
+++ b/templates/facetHorizontal.hbs
@@ -4,27 +4,31 @@
 {{/if}}
 ">
 	<div class="facet-range">
-        <svg class="facet-histogram"></svg>
-        <div class="facet-range-filter facet-range-filter-init">
-            <div class="facet-range-filter-slider facet-range-filter-left">
-            </div>
-            <div class="facet-range-filter-slider facet-range-filter-right">
-            </div>
-        </div>
+		<svg class="facet-histogram"></svg>
+		{{#if filterable}}
+			<div class="facet-range-filter facet-range-filter-init">
+				<div class="facet-range-filter-slider facet-range-filter-left">
+				</div>
+				<div class="facet-range-filter-slider facet-range-filter-right">
+				</div>
+			</div>
+		{{/if}}
 	</div>
-    <div class="facet-range-labels">
-        <div class="facet-range-label">{{leftRangeLabel}}</div>
-        <div class="facet-range-label">{{rightRangeLabel}}</div>
-    </div>
-    <div class="facet-range-controls">
-        <div class="facet-page-left facet-page-ctrl">
-            <i class="fa fa-chevron-left"></i>
-        </div>
-        <div class="facet-range-current">
-			{{leftRangeLabel}} - {{rightRangeLabel}}
-        </div>
-        <div class="facet-page-right facet-page-ctrl">
-            <i class="fa fa-chevron-right"></i>
-        </div>
-    </div>
+	<div class="facet-range-labels">
+		<div class="facet-range-label">{{leftRangeLabel}}</div>
+		<div class="facet-range-label">{{rightRangeLabel}}</div>
+	</div>
+	{{#if filterable}}
+		<div class="facet-range-controls">
+			<div class="facet-page-left facet-page-ctrl">
+				<i class="fa fa-chevron-left"></i>
+			</div>
+			<div class="facet-range-current">
+				{{leftRangeLabel}} - {{rightRangeLabel}}
+			</div>
+			<div class="facet-page-right facet-page-ctrl">
+				<i class="fa fa-chevron-right"></i>
+			</div>
+		</div>
+	{{/if}}
 </div>

--- a/templates/group.hbs
+++ b/templates/group.hbs
@@ -1,10 +1,12 @@
 <div class="facets-group-container">
 	<div class="facets-group">
 		<div class="group-header">
-			<div class="group-expander">
-				<i class="fa fa-check-square-o toggle"></i>
-			</div>
-            {{{label}}}
+			{{#if collapsible}}
+				<div class="group-expander">
+					<i class="fa fa-check-square-o toggle"></i>
+				</div>
+			{{/if}}
+			{{{label}}}
 		</div>
 		<div class="group-facet-container-outer">
 			<div class="group-facet-container"></div>


### PR DESCRIPTION
- add a `collapsible` option to disable collapsing a facet group. Defaults to `true`.
- add a `filterable` option to disable filtering a histogram facet. Defaults to `true`.