### PR TITLE
Ensure `_total` is reset prior to calculating.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facets Component developed by Uncharted Software",
   "repository": "https://github.com/unchartedsoftware/stories-facets",
   "license": "Apache-2.0",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "devDependencies": {
     "body-parser": "~1.13.2",
     "browserify": "^12.0.1",

--- a/src/components/group.js
+++ b/src/components/group.js
@@ -507,6 +507,7 @@ Group.prototype._initializeFacets = function (spec) {
 		this._total = spec.total;
 	} else {
 		this._ownsTotal = false;
+		this._total = 0;
 		spec.facets.forEach(function (facetSpec) {
 			if (!('histogram' in facetSpec) && !('placeholder' in facetSpec)) { // it's not a horizontal or placeholder facet
 				this._total += facetSpec.count;


### PR DESCRIPTION
When `_initializeFacets` is called, `_total` was never reset before calculating. This wasn't an issue prior to `replaceGroup` being added to the interface.

Facets now scale properly when replaced with updated data.

Resolves #24