### PR TITLE
allow badges to be created for values which aren't included in the fa…

### DIFF
--- a/examples/badges/badges.js
+++ b/examples/badges/badges.js
@@ -42,8 +42,8 @@ function main() {
   $('<button/>')
       .text('Multiple Badges')
       .click(function() {
-        //Cannot create a badge whose key/value does not exist as a facet
-        facets.createBadges([{ key : 'name', value: 'Mary'}, {key: 'name', value: 'Debbie'}, { key : 'fakeKey', value: 'fakeValue'}]);
+        //Badges can be created, even if they don't correspond to a facet
+        facets.createBadges([{ key : 'name', value: 'Mary'}, {key: 'name', value: 'Debbie'}, { key : 'hiddenFacetKey', value: 'hidden facet value'}]);
       })
       .appendTo($controls);
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facets Component developed by Uncharted Software",
   "repository": "https://github.com/unchartedsoftware/stories-facets",
   "license": "Apache-2.0",
-  "version": "2.12.4",
+  "version": "2.12.5",
   "devDependencies": {
     "body-parser": "~1.13.2",
     "browserify": "^12.0.1",

--- a/src/components/badge.js
+++ b/src/components/badge.js
@@ -83,7 +83,7 @@ Object.defineProperty(Badge.prototype, 'label', {
 });
 
 /**
- * Appends the badge element to the DON, adds event handlers.
+ * Appends the badge element to the DOM, adds event handlers.
  *
  * @method _initialize
  * @private

--- a/src/main.js
+++ b/src/main.js
@@ -199,8 +199,7 @@ Facets.prototype.highlight = function(simpleGroups, isQuery) {
 Facets.prototype.createBadges = function(simpleGroups, isQuery) {
 
   simpleGroups.forEach(function(simpleGroup) {
-		var group = this.getGroup(simpleGroup.key);
-		if (!isQuery && group) {
+		if (!isQuery) {
 			this._badgeGroup._createBadge(simpleGroup);
 		} else {
 			var query = this._getQuery(simpleGroup.key, simpleGroup.value);


### PR DESCRIPTION
…cets

Allows badges to be displayed for values that don't correspond to a visible facet. An example use case is that a user selects a facet, then hides the facet group.