### PR TITLE
Histogram origin line

### DIFF
--- a/examples/histogram-origin/histogram.css
+++ b/examples/histogram-origin/histogram.css
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Uncharted Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#facet-container {
+	width: 240px;
+	padding:5px;
+	font-family : Helvetica;
+}

--- a/examples/histogram-origin/histogram.js
+++ b/examples/histogram-origin/histogram.js
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2017 Uncharted Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function main() {
+
+	var container = $('#facet-container');
+
+	var groups = [
+		{
+			label : 'Start of Bar',
+			key : 'start-of-bar',
+			facets : [
+				{
+					"histogram": {
+						showOrigin: true,
+						"slices": [
+							{
+								"label": "-10",
+								"toLabel": "0",
+								"count": 6
+							},
+							{
+								"label": "0",
+								"toLabel": "10",
+								"count": 23
+							},
+							{
+								"label": "10",
+								"toLabel": "20",
+								"count": 49
+							},
+							{
+								"label": "20",
+								"toLabel": "30",
+								"count": 34
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			label : 'First Quarter of Bar',
+			key : 'first-quarter-of-bar',
+			facets : [
+				{
+					"histogram": {
+						showOrigin: true,
+						"slices": [
+							{
+								"label": "-12.5",
+								"toLabel": "-2.5",
+								"count": 6
+							},
+							{
+								"label": "-2.5",
+								"toLabel": "7.5",
+								"count": 23
+							},
+							{
+								"label": "7.5",
+								"toLabel": "17.5",
+								"count": 49
+							},
+							{
+								"label": "17.5",
+								"toLabel": "27.5",
+								"count": 34
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			label : 'Middle of Bar',
+			key : 'middle-of-bar',
+			facets : [
+				{
+					"histogram": {
+						showOrigin: true,
+						"slices": [
+							{
+								"label": "-15",
+								"toLabel": "-5",
+								"count": 6
+							},
+							{
+								"label": "-5",
+								"toLabel": "5",
+								"count": 23
+							},
+							{
+								"label": "5",
+								"toLabel": "15",
+								"count": 49
+							},
+							{
+								"label": "15",
+								"toLabel": "25",
+								"count": 34
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			label : 'Third Quarter of Bar',
+			key : 'third-quarter-of-bar',
+			facets : [
+				{
+					"histogram": {
+						showOrigin: true,
+						"slices": [
+							{
+								"label": "-17.5",
+								"toLabel": "-7.5",
+								"count": 6
+							},
+							{
+								"label": "-7.5",
+								"toLabel": "2.5",
+								"count": 23
+							},
+							{
+								"label": "2.5",
+								"toLabel": "12.5",
+								"count": 49
+							},
+							{
+								"label": "12.5",
+								"toLabel": "22.5",
+								"count": 34
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			label : 'End of Bar',
+			key : 'end-of-bar',
+			facets : [
+				{
+					"histogram": {
+						showOrigin: true,
+						"slices": [
+							{
+								"label": "-20",
+								"toLabel": "-10",
+								"count": 6
+							},
+							{
+								"label": "-10",
+								"toLabel": "0",
+								"count": 23
+							},
+							{
+								"label": "0",
+								"toLabel": "10",
+								"count": 49
+							},
+							{
+								"label": "10",
+								"toLabel": "20",
+								"count": 34
+							}
+						]
+					}
+				}
+			]
+		},
+	];
+
+	var facets = new Facets(container, groups);
+}

--- a/examples/histogram-origin/index.html
+++ b/examples/histogram-origin/index.html
@@ -1,0 +1,36 @@
+<!--
+  ~ Copyright 2017 Uncharted Software Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Facets Histogram Example</title>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Oswald">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../../dist/facets.css">
+    <link rel="stylesheet" href="./histogram.css">
+    <script src="../../dist/facets.extern.js"></script>
+    <script src="../../dist/facets.js"></script>
+    <script src="./histogram.js"></script>
+</head>
+<body>
+<div id="facet-container"></div>
+<script>
+    main();
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facets Component developed by Uncharted Software",
   "repository": "https://github.com/unchartedsoftware/stories-facets",
   "license": "Apache-2.0",
-  "version": "2.12.5",
+  "version": "2.12.6",
   "devDependencies": {
     "body-parser": "~1.13.2",
     "browserify": "^12.0.1",

--- a/sass/_facet.scss
+++ b/sass/_facet.scss
@@ -322,6 +322,7 @@
 		display: block;
 		width: 100%;
 		height: 100%;
+		overflow: visible;
 	}
 
 	g:hover .facet-histogram-bar {

--- a/src/components/facet/facetHistogram.js
+++ b/src/components/facet/facetHistogram.js
@@ -113,9 +113,6 @@ FacetHistogram.prototype.initializeSlices = function(svg, slices) {
 	var stackedBarsNumber = Math.ceil(barsLength / maxBarsNumber);
 	var barsToCreate = Math.ceil(barsLength / stackedBarsNumber);
 
-	var originLineWidth = 2;
-	//var containerWidth = this._showOrigin ? svgWidth - originLineWidth : svgWidth;
-
 	var barWidth = Math.floor((svgWidth - ((barsToCreate - 1) * barPadding)) / barsToCreate);
 	barWidth = Math.max(barWidth, minBarWidth);
 	barWidth = Math.min(barWidth, maxBarWidth);

--- a/src/components/facet/facetHorizontal.js
+++ b/src/components/facet/facetHorizontal.js
@@ -251,7 +251,8 @@ FacetHorizontal.prototype.processSpec = function(inData) {
  */
 FacetHorizontal.prototype.processHistogram = function(inData) {
 	var outData = {
-		slices: []
+		slices: [],
+		showOrigin: inData.showOrigin
 	};
 
 	var inSlices = inData.slices;


### PR DESCRIPTION
This adds an optional argument to histogram facets to display a origin line marked `0`. 

Added an example to show how it behaves when the value is on the edge or inside the bar, as seen below:

<img width="256" alt="screen shot 2018-07-05 at 4 36 38 pm" src="https://user-images.githubusercontent.com/8975956/42346754-a40051ce-8071-11e8-9891-f12193d09e1d.png">
