### PR TITLE
Bugfix/memex 4479

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facets Component developed by Uncharted Software",
   "repository": "https://github.com/unchartedsoftware/stories-facets",
   "license": "Apache-2.0",
-  "version": "2.12.10",
+  "version": "2.12.11",
   "devDependencies": {
     "body-parser": "~1.13.2",
     "browserify": "^12.0.1",

--- a/src/components/facet/facetHistogram.js
+++ b/src/components/facet/facetHistogram.js
@@ -239,7 +239,7 @@ FacetHistogram.prototype.barRangeToPixelRange = function (barRange) {
 FacetHistogram.prototype.highlightRange = function (range) {
 	var bars = this._bars;
 	for (var i = 0, n = bars.length; i < n; ++i) {
-		bars[i].highlighted = (i >= range.from && i <= range.to);
+          bars[i].highlighted = this._spec.alwaysHighlight || (i >= range.from && i <= range.to);
 	}
 };
 

--- a/src/components/facet/facetHorizontal.js
+++ b/src/components/facet/facetHorizontal.js
@@ -232,6 +232,7 @@ FacetHorizontal.prototype.deselect = function() {
 FacetHorizontal.prototype.processSpec = function(inData) {
 	var histogram = this.processHistogram(inData.histogram);
 	histogram.scaleFn = inData.scaleFn;
+        histogram.alwaysHighlight = inData.alwaysHighlight;
 	var firstSlice = histogram.slices[0];
 	var lastSlice = histogram.slices[histogram.slices.length - 1];
 

--- a/src/components/group.js
+++ b/src/components/group.js
@@ -325,7 +325,7 @@ Group.prototype.append = function (groupSpec) {
 			facetSpec.count += existingFacet.count;
 			existingFacet.updateSpec(facetSpec);
 		} else {
-			var facet = this._createNewFacet(facetSpec, groupSpec.key, true, groupSpec.displayFn);
+			var facet = this._createNewFacet(facetSpec, groupSpec.key, true, groupSpec.displayFn, groupSpec.alwaysHighlight);
 			if (facet instanceof FacetHorizontal) {
 				this.horizontalFacets.push(facet);
 			} else {
@@ -525,7 +525,7 @@ Group.prototype._initializeFacets = function (spec) {
 	var facets = spec.facets;
 	for (var i = 0, n = facets.length; i < n; ++i) {
 		var facetSpec = facets[i];
-		var facet = this._createNewFacet(facetSpec, spec.key, false, spec.displayFn);
+		var facet = this._createNewFacet(facetSpec, spec.key, false, spec.displayFn, spec.alwaysHighlight);
 		if (facet instanceof FacetHorizontal) {
 			this.horizontalFacets.push(facet);
 		} else {
@@ -704,13 +704,14 @@ Group.prototype._updateLess = function (less) {
  * @param {Function} displayFn - Specify a function to be used to transform values to display values.
  * @private
  */
-Group.prototype._createNewFacet = function (facetSpec, groupKey, hidden, displayFn) {
+Group.prototype._createNewFacet = function (facetSpec, groupKey, hidden, displayFn, alwaysHighlight) {
 	if ('histogram' in facetSpec) {
 		// create a horizontal facet
 		return new FacetHorizontal(this._facetContainer, this, _.extend(facetSpec, {
 			key: groupKey,
                   hidden: hidden,
-                  displayFn: displayFn
+                  displayFn: displayFn,
+                  alwaysHighlight: alwaysHighlight || false
 		}));
 	} else if ('placeholder' in facetSpec) {
 		// create a placeholder facet


### PR DESCRIPTION
Add `alwaysHighlight` option to histogram spec which highlights values even if they fall outside of the highlighted Range. This fixes an inconsistency when a document contains multiple values for a given attribute.

For example:
![captura de pantalla 2019-01-02 a la s 9 57 40 a m](https://user-images.githubusercontent.com/4534106/50597396-4c905280-0e75-11e9-98da-c7ac148ade91.png)

In the screenshot above, even though just the age 22 is selected in the histogram, some documents include multiple ages and are appropriately highlighted.