### PR TITLE
Multi vertical timeseries min/max X pos fix

### DIFF
--- a/examples/timeseries-vertical/timeseries.js
+++ b/examples/timeseries-vertical/timeseries.js
@@ -59,7 +59,7 @@ function main() {
 					value: 'Maya',
 					multipleTimeseries : [
 						[0,0,0,4,2,0,0,0,0,0,0],
-						[0,0,1,2,0,3,0,0,0,4,1]
+						[0,0,1,2,0,3,0,0,4,1]
 					],
 					colors: [
 						'goldenrod',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@uncharted.software/stories-facets",
-  "version": "2.12.16",
+  "version": "2.12.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Facets Component developed by Uncharted Software",
   "repository": "https://github.com/unchartedsoftware/stories-facets",
   "license": "Apache-2.0",
-  "version": "2.12.16",
+  "version": "2.12.17",
   "devDependencies": {
     "body-parser": "~1.18.3",
     "browserify": "^16.2.3",

--- a/src/components/facet/facetVertical.js
+++ b/src/components/facet/facetVertical.js
@@ -399,7 +399,7 @@ FacetVertical.prototype._removeHandlers = function() {
  * @method _renderSparkline
  * @private
  */
-FacetVertical.prototype._renderSparkline = function(width, height, sparkline, maxValue, index) {
+FacetVertical.prototype._renderSparkline = function(width, height, sparkline, minXValue, maxXValue, maxYValue, index) {
 
 	var x = 0, y = 0;
 	var i;
@@ -407,30 +407,22 @@ FacetVertical.prototype._renderSparkline = function(width, height, sparkline, ma
 
 	if (sparkline.length > 0 && Array.isArray(sparkline[0])) {
 		// each entry is two values, x and y
-
-		var first = sparkline[0];
-		var last = sparkline[sparkline.length - 1];
-		var xrange = last[TIMESERIES_X_INDEX] - first[TIMESERIES_X_INDEX];
-
-		var lastEntry;
+		var xrange = maxXValue - minXValue;
 		for (i = 0; i < sparkline.length; i++) {
 			var entry = sparkline[i];
-			if (lastEntry) {
-				x += width * ((entry[TIMESERIES_X_INDEX] - lastEntry[TIMESERIES_X_INDEX]) / xrange);
-			}
-			y = height - Math.floor((entry[TIMESERIES_Y_INDEX])/maxValue * height) + 1;
+			x = width * ((entry[TIMESERIES_X_INDEX] - minXValue) / xrange);
+			y = height - Math.floor((entry[TIMESERIES_Y_INDEX])/maxYValue * height) + 1;
 			pathData += (x + ' ' + y);
 			if (i < sparkline.length-1) {
 				pathData += ' L ';
 			}
-			lastEntry = entry;
 		}
 	} else {
 		// each entry is one value, y
-		var dx = width / (sparkline.length-1);
+		var dx = width / (maxXValue);
 
 		for (i = 0; i < sparkline.length; i++) {
-			y = height - Math.floor((sparkline[i])/maxValue * height) + 1;
+			y = height - Math.floor((sparkline[i])/maxYValue * height) + 1;
 			pathData += (x + ' ' + y);
 			if (i < sparkline.length-1) {
 				pathData += ' L ';
@@ -511,8 +503,8 @@ FacetVertical.prototype._updateSparkline = function() {
 
 			} else {
 
-				this._minX = 0;
-				this._maxX = Math.max(this._maxX, subseries.length - 1);
+				that._minX = 0;
+				that._maxX = Math.max(that._maxX, subseries.length - 1);
 
 				for (i=0; i<subseries.length; i++) {
 					that._minY = Math.min(that._minY, subseries[i]);
@@ -572,7 +564,7 @@ FacetVertical.prototype._updateSparkline = function() {
 		// muiltiple sparkline
 
 		this._sparkline.forEach(function(subseries, index) {
-			var totalSparklinePath = that._renderSparkline(that._sparkWidth, that._sparkHeight, subseries, that._maxY, index);
+			var totalSparklinePath = that._renderSparkline(that._sparkWidth, that._sparkHeight, subseries, that._minX, that._maxX, that._maxY, index);
 			totalSparklinePath.appendTo(that._sparklineSVG);
 
 			if (that._spec.selected && that._spec.selected.timeseries) {
@@ -583,7 +575,7 @@ FacetVertical.prototype._updateSparkline = function() {
 		});
 
 		if (this._spec.selected && this._spec.selected.timeseries) {
-			var selectedSparklinePath = this._renderSparkline(this._sparkWidth, this._sparkHeight, this._spec.selected.timeseries, this._maxY, 0);
+			var selectedSparklinePath = this._renderSparkline(this._sparkWidth, this._sparkHeight, this._spec.selected.timeseries, this._minX, this._maxX, this._maxY, 0);
 			selectedSparklinePath.appendTo(this._sparklineSVG);
 
 			selectedSparklinePath[0].classList.add('facet-sparkline-selected');
@@ -596,11 +588,11 @@ FacetVertical.prototype._updateSparkline = function() {
 	} else {
 		// single sparkline
 
-		var totalSparklinePath = this._renderSparkline(this._sparkWidth, this._sparkHeight, this._sparkline, this._maxY, 0);
+		var totalSparklinePath = this._renderSparkline(this._sparkWidth, this._sparkHeight, this._sparkline, this._minX, this._maxX, this._maxY, 0);
 		totalSparklinePath.appendTo(this._sparklineSVG);
 
 		if (this._spec.selected && this._spec.selected.timeseries) {
-			var selectedSparklinePath = this._renderSparkline(this._sparkWidth, this._sparkHeight, this._spec.selected.timeseries, this._maxY, 0);
+			var selectedSparklinePath = this._renderSparkline(this._sparkWidth, this._sparkHeight, this._spec.selected.timeseries, this._minX, this._maxX, this._maxY, 0);
 			selectedSparklinePath.appendTo(this._sparklineSVG);
 
 			totalSparklinePath[0].classList.add('facet-sparkline-total');


### PR DESCRIPTION
#44 added support for rendering multi-timeseries, but the X positions of the timeseries were not being calculated properly.  In the vertical timeseries example we define the values for `Linda` as:

https://github.com/unchartedsoftware/stories-facets/blob/10d301c24ef9da1ddc23c1cf382c9992114510ae/examples/timeseries-vertical/timeseries.js#L35-L38

Both timeseries start at `0`, but have differing end points of `10` and `22`.  When rendered they appeared incorrectly, having the same time range:

![image](https://user-images.githubusercontent.com/8959554/63886993-c0094600-c9a9-11e9-8bef-b5753096a39b.png)

We now use the min/max for the set of timeseries being rendered, resulting in:

![image](https://user-images.githubusercontent.com/8959554/63887122-170f1b00-c9aa-11e9-9c1a-590e5225f5ea.png)


